### PR TITLE
[Feat] 사용자 CRUD

### DIFF
--- a/user-service/src/main/java/com/oneonone/userservice/application/command/UpdateMasterCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/UpdateMasterCommand.java
@@ -1,0 +1,13 @@
+package com.oneonone.userservice.application.command;
+
+import com.oneonone.common.enums.UserRole;
+import com.oneonone.userservice.domain.enums.UserStatus;
+
+public record UpdateMasterCommand(
+        String nickname,
+        UserRole role,
+        UserStatus status,
+        Long pointBalance,
+        String slackId
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/command/UpdatePointCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/UpdatePointCommand.java
@@ -1,0 +1,6 @@
+package com.oneonone.userservice.application.command;
+
+public record UpdatePointCommand(
+        Long amount
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/command/UpdateUserCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/UpdateUserCommand.java
@@ -1,0 +1,8 @@
+package com.oneonone.userservice.application.command;
+
+public record UpdateUserCommand(
+        String password,
+        String nickname,
+        String slackId
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/dto/UserInfo.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/dto/UserInfo.java
@@ -1,0 +1,27 @@
+package com.oneonone.userservice.application.dto;
+
+import com.oneonone.common.enums.UserRole;
+import com.oneonone.userservice.domain.entity.User;
+import com.oneonone.userservice.domain.enums.UserStatus;
+
+public record UserInfo(
+        Long userId,
+        String username,
+        String nickname,
+        UserRole role,
+        UserStatus status,
+        Long pointBalance,
+        String slackId
+) {
+    public static UserInfo from(User user) {
+        return new UserInfo(
+                user.getUserId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getRole(),
+                user.getStatus(),
+                user.getPointBalance(),
+                user.getSlackId()
+        );
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -9,7 +9,6 @@ import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
-import com.oneonone.userservice.presentation.dto.request.UpdateMasterRequest;
 import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
 import com.oneonone.userservice.presentation.dto.response.PointResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -2,11 +2,13 @@ package com.oneonone.userservice.application.service;
 
 import com.oneonone.common.exception.BusinessException;
 import com.oneonone.userservice.application.command.SignupCommand;
+import com.oneonone.userservice.application.command.UpdateMasterCommand;
 import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
+import com.oneonone.userservice.presentation.dto.request.UpdateMasterRequest;
 import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
@@ -76,9 +78,25 @@ public class UserService {
         return MasterUserResponse.from(userInfo);
     }
 
-    private User findUserById(Long userId) {
-        return userRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    @Transactional
+    public MasterUserResponse updateUser(Long userId, UpdateMasterCommand command) {
+        User user = findUserById(userId);
+        if (command.nickname() != null && userRepository.existsByNickname(command.nickname())) {
+            throw new BusinessException(UserErrorCode.INVALID_NICKNAME);
+        }
+        user.updateByMaster(
+                command.nickname(),
+                command.role(),
+                command.status(),
+                command.pointBalance(),
+                command.slackId()
+        );
+        UserInfo userInfo = UserInfo.from(user);
+        return MasterUserResponse.from(userInfo);
     }
 
+    private User findUserById(Long userId) {
+        return userRepository.findByUserIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -3,11 +3,15 @@ package com.oneonone.userservice.application.service;
 import com.oneonone.common.exception.BusinessException;
 import com.oneonone.userservice.application.command.SignupCommand;
 import com.oneonone.userservice.application.command.UpdateUserCommand;
+import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
+import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +40,8 @@ public class UserService {
 
     public UserResponse getMyProfile(Long userId) {
         User user = findUserById(userId);
-        return UserResponse.from(user);
+        UserInfo userInfo = UserInfo.from(user);
+        return UserResponse.from(userInfo);
     }
 
     @Transactional
@@ -50,17 +55,24 @@ public class UserService {
                 encodedPw,
                 command.nickname(),
                 command.slackId());
-        return UserResponse.from(user);
+        UserInfo userInfo = UserInfo.from(user);
+        return UserResponse.from(userInfo);
     }
 
     @Transactional
     public void deleteMyProfile(Long userId) {
         User user = findUserById(userId);
-//        user.softDelete(userId); // TODO: 주석 해제
+        user.softDelete(userId);
+    }
+
+    public Page<MasterUserResponse> getAllUsers(Pageable pageable) {
+        Page<UserInfo> users = userRepository.findAllByDeletedAtIsNull(pageable);
+        return users.map(MasterUserResponse::from);
     }
 
     private User findUserById(Long userId) {
         return userRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
     }
+
 }

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -53,6 +53,12 @@ public class UserService {
         return UserResponse.from(user);
     }
 
+    @Transactional
+    public void deleteMyProfile(Long userId) {
+        User user = findUserById(userId);
+//        user.softDelete(userId); // TODO: 주석 해제
+    }
+
     private User findUserById(Long userId) {
         return userRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
     @Transactional
     public UserResponse updateMyProfile(Long userId, UpdateUserCommand command) {
         User user = findUserById(userId);
-        if (command.nickname() != null && userRepository.existsByNickname(command.nickname())) {
+        if (command.nickname() != null && userRepository.existsByNicknameAndDeletedAtIsNull(command.nickname())) {
             throw new BusinessException(UserErrorCode.INVALID_NICKNAME);
         }
         String encodedPw = command.password() != null ? passwordEncoder.encode(command.password()) : null;
@@ -81,7 +81,7 @@ public class UserService {
     @Transactional
     public MasterUserResponse updateUser(Long userId, UpdateMasterCommand command) {
         User user = findUserById(userId);
-        if (command.nickname() != null && userRepository.existsByNickname(command.nickname())) {
+        if (command.nickname() != null && userRepository.existsByNicknameAndDeletedAtIsNull(command.nickname())) {
             throw new BusinessException(UserErrorCode.INVALID_NICKNAME);
         }
         user.updateByMaster(

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -3,6 +3,7 @@ package com.oneonone.userservice.application.service;
 import com.oneonone.common.exception.BusinessException;
 import com.oneonone.userservice.application.command.SignupCommand;
 import com.oneonone.userservice.application.command.UpdateMasterCommand;
+import com.oneonone.userservice.application.command.UpdatePointCommand;
 import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
@@ -10,6 +11,7 @@ import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
 import com.oneonone.userservice.presentation.dto.request.UpdateMasterRequest;
 import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
+import com.oneonone.userservice.presentation.dto.response.PointResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -99,6 +101,20 @@ public class UserService {
     public void deleteByMaster(Long id, Long userId) {
         User user = findUserById(userId);
         user.softDelete(id);
+    }
+
+    public PointResponse getPoint(Long userId) {
+        User user = findUserById(userId);
+        UserInfo userInfo = UserInfo.from(user);
+        return PointResponse.from(userInfo);
+    }
+
+    @Transactional
+    public PointResponse updatePoint(Long userId, UpdatePointCommand command) {
+        User user = findUserById(userId);
+        user.updatePoint(command.amount());
+        UserInfo userInfo = UserInfo.from(user);
+        return PointResponse.from(userInfo);
     }
 
     private User findUserById(Long userId) {

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -95,6 +95,12 @@ public class UserService {
         return MasterUserResponse.from(userInfo);
     }
 
+    @Transactional
+    public void deleteByMaster(Long id, Long userId) {
+        User user = findUserById(userId);
+        user.softDelete(id);
+    }
+
     private User findUserById(Long userId) {
         return userRepository.findByUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -39,6 +39,7 @@ public class UserService {
         return UserResponse.from(user);
     }
 
+    @Transactional
     public UserResponse updateMyProfile(Long userId, UpdateUserCommand command) {
         User user = findUserById(userId);
         if (command.nickname() != null && userRepository.existsByNickname(command.nickname())) {

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -70,6 +70,12 @@ public class UserService {
         return users.map(MasterUserResponse::from);
     }
 
+    public MasterUserResponse getUser(Long userId) {
+        User user = findUserById(userId);
+        UserInfo userInfo = UserInfo.from(user);
+        return MasterUserResponse.from(userInfo);
+    }
+
     private User findUserById(Long userId) {
         return userRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.oneonone.userservice.application.service;
 
 import com.oneonone.common.exception.BusinessException;
 import com.oneonone.userservice.application.command.SignupCommand;
+import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
@@ -34,7 +35,25 @@ public class UserService {
     }
 
     public UserResponse getMyProfile(Long userId) {
-        User user = userRepository.findByUserId(userId).orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = findUserById(userId);
         return UserResponse.from(user);
+    }
+
+    public UserResponse updateMyProfile(Long userId, UpdateUserCommand command) {
+        User user = findUserById(userId);
+        if (command.nickname() != null && userRepository.existsByNickname(command.nickname())) {
+            throw new BusinessException(UserErrorCode.INVALID_NICKNAME);
+        }
+        String encodedPw = command.password() != null ? passwordEncoder.encode(command.password()) : null;
+        user.updateMyProfile(
+                encodedPw,
+                command.nickname(),
+                command.slackId());
+        return UserResponse.from(user);
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
@@ -1,8 +1,10 @@
 package com.oneonone.userservice.domain.entity;
 
 import com.oneonone.common.enums.UserRole;
+import com.oneonone.common.exception.BusinessException;
 import com.oneonone.common.model.BaseEntity;
 import com.oneonone.userservice.domain.enums.UserStatus;
+import com.oneonone.userservice.exception.UserErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -54,5 +56,21 @@ public class User extends BaseEntity {
                 .pointBalance(0L)
                 .slackId(slackId)
                 .build();
+    }
+
+    public void updateMyProfile(String password,
+                              String nickname,
+                              String slackId) {
+        if (password != null && !password.isBlank()) this.password = password;
+        if (nickname != null) {
+            validate(nickname);
+            this.nickname = nickname;
+        }
+        if (slackId != null) this.slackId = slackId;
+    }
+
+    public void validate(String nickname) {
+        if (nickname.length() < 2) throw new BusinessException(UserErrorCode.INVALID_NICKNAME);
+        // TODO: slack ID 등 검증 필요 시 추가
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
@@ -80,8 +80,16 @@ public class User extends BaseEntity {
         }
         if (role != null) this.role = role;
         if (status != null) this.status = status;
-        if (pointBalance != null) this.pointBalance = pointBalance;
+        if (pointBalance != null) {
+            if (pointBalance < 0) throw new BusinessException(UserErrorCode.INVALID_POINT);
+            this.pointBalance = pointBalance;
+        }
         if (slackId != null) this.slackId = slackId;
+    }
+
+    public void updatePoint(Long amount) {
+        if (this.pointBalance + amount < 0) throw new BusinessException(UserErrorCode.INVALID_POINT);
+        this.pointBalance += amount;
     }
 
     public void validate(String nickname) {

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
@@ -69,6 +69,21 @@ public class User extends BaseEntity {
         if (slackId != null) this.slackId = slackId;
     }
 
+    public void updateByMaster(String nickname,
+                               UserRole role,
+                               UserStatus status,
+                               Long pointBalance,
+                               String slackId) {
+        if (nickname != null) {
+            validate(nickname);
+            this.nickname = nickname;
+        }
+        if (role != null) this.role = role;
+        if (status != null) this.status = status;
+        if (pointBalance != null) this.pointBalance = pointBalance;
+        if (slackId != null) this.slackId = slackId;
+    }
+
     public void validate(String nickname) {
         if (nickname.length() < 2) throw new BusinessException(UserErrorCode.INVALID_NICKNAME);
         // TODO: slack ID 등 검증 필요 시 추가

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
@@ -17,7 +17,7 @@ public interface UserRepository {
 
     Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 
     Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package com.oneonone.userservice.domain.repository;
 
+import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import javax.swing.text.html.Option;
 import java.util.Optional;
@@ -15,4 +18,6 @@ public interface UserRepository {
     Optional<User> findByUserId(Long userId);
 
     boolean existsByNickname(String nickname);
+
+    Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByUserId(Long userId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
@@ -5,7 +5,6 @@ import com.oneonone.userservice.domain.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface UserRepository {

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository {
 
     Optional<User> findByUsername(String username);
 
-    Optional<User> findByUserId(Long userId);
+    Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
 
     boolean existsByNickname(String nickname);
 

--- a/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
@@ -12,7 +12,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "U003", "비밀번호가 일치하지 않습니다."),
-    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "U004", "사용할 수 없는 닉네임입니다.");
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "U004", "사용할 수 없는 닉네임입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "U005", "접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
@@ -11,7 +11,8 @@ public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
-    INVALID_PASSWORD(HttpStatus.FORBIDDEN, "U003", "비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD(HttpStatus.FORBIDDEN, "U003", "비밀번호가 일치하지 않습니다."),
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "U004", "사용할 수 없는 닉네임입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
@@ -13,7 +13,8 @@ public enum UserErrorCode implements ErrorCode {
     DUPLICATE_USER(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자입니다."),
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "U003", "비밀번호가 일치하지 않습니다."),
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "U004", "사용할 수 없는 닉네임입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "U005", "접근 권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "U005", "접근 권한이 없습니다."),
+    INVALID_POINT(HttpStatus.BAD_REQUEST, "U006", "포인트는 음수가 될 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
@@ -13,9 +13,9 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
-    Optional<User> findByUserId(Long userId);
-
     boolean existsByNickname(String nickname);
 
     Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
@@ -13,9 +13,9 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
-    boolean existsByNickname(String nickname);
-
     Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable);
 
     Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
+
+    boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
@@ -11,4 +11,6 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByUserId(Long userId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
@@ -1,6 +1,9 @@
 package com.oneonone.userservice.infrastructure.repository;
 
+import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -13,4 +16,6 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(Long userId);
 
     boolean existsByNickname(String nickname);
+
+    Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -1,8 +1,11 @@
 package com.oneonone.userservice.infrastructure.repository;
 
+import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -36,5 +39,10 @@ public class UserRepositoryAdapter implements UserRepository {
     @Override
     public boolean existsByNickname(String nickname) {
         return jpaUserRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable) {
+        return jpaUserRepository.findAllByDeletedAtIsNull(pageable);
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -32,8 +32,8 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByUserId(Long userId) {
-        return jpaUserRepository.findByUserId(userId);
+    public Optional<User> findByUserIdAndDeletedAtIsNull(Long userId) {
+        return jpaUserRepository.findByUserIdAndDeletedAtIsNull(userId);
     }
 
     @Override

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -32,4 +32,9 @@ public class UserRepositoryAdapter implements UserRepository {
     public Optional<User> findByUserId(Long userId) {
         return jpaUserRepository.findByUserId(userId);
     }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        return jpaUserRepository.existsByNickname(nickname);
+    }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -37,8 +37,8 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
-    public boolean existsByNickname(String nickname) {
-        return jpaUserRepository.existsByNickname(nickname);
+    public boolean existsByNicknameAndDeletedAtIsNull(String nickname) {
+        return jpaUserRepository.existsByNicknameAndDeletedAtIsNull(nickname);
     }
 
     @Override

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryImpl.java
@@ -6,13 +6,13 @@ import com.oneonone.userservice.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Component
+@Repository
 @RequiredArgsConstructor
-public class UserRepositoryAdapter implements UserRepository {
+public class UserRepositoryImpl implements UserRepository {
 
     private final JpaUserRepository jpaUserRepository;
 

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -93,4 +93,13 @@ public class UserController {
         Page<MasterUserResponse> response = userService.getAllUsers(pageable);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 목록 조회 성공"));
     }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<MasterUserResponse>> getUserDetail(
+            @RequestHeader("X-User-Role") String role,
+            @PathVariable Long userId) {
+        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        MasterUserResponse response = userService.getUser(userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 조회 성공"));
+    }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -3,11 +3,13 @@ package com.oneonone.userservice.presentation;
 import com.oneonone.common.response.ApiResponse;
 import com.oneonone.userservice.application.command.LoginCommand;
 import com.oneonone.userservice.application.command.SignupCommand;
+import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.service.AuthService;
 import com.oneonone.userservice.application.service.UserService;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.presentation.dto.request.LoginRequest;
 import com.oneonone.userservice.presentation.dto.request.SignupRequest;
+import com.oneonone.userservice.presentation.dto.request.UpdateUserRequest;
 import com.oneonone.userservice.presentation.dto.response.LoginResponse;
 import com.oneonone.userservice.presentation.dto.response.SignupResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
@@ -53,6 +55,19 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserResponse>> getMyProfile(
             @RequestHeader("X-User-Id") Long userId) {
         UserResponse response = userService.getMyProfile(userId);
-        return ResponseEntity.ok(ApiResponse.success(response, "사용자 정보 조회 성공"));
+        return ResponseEntity.ok(ApiResponse.success(response, "내 정보 조회 성공"));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> updateMyProfile(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody UpdateUserRequest request) {
+        UpdateUserCommand command = new UpdateUserCommand(
+                request.password(),
+                request.nickname(),
+                request.slackId()
+        );
+        UserResponse response = userService.updateMyProfile(userId, command);
+        return ResponseEntity.ok(ApiResponse.success(response, "내 정보 업데이트 성공"));
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -4,6 +4,7 @@ import com.oneonone.common.exception.BusinessException;
 import com.oneonone.common.response.ApiResponse;
 import com.oneonone.userservice.application.command.LoginCommand;
 import com.oneonone.userservice.application.command.SignupCommand;
+import com.oneonone.userservice.application.command.UpdateMasterCommand;
 import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.service.AuthService;
 import com.oneonone.userservice.application.service.UserService;
@@ -11,6 +12,7 @@ import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.exception.UserErrorCode;
 import com.oneonone.userservice.presentation.dto.request.LoginRequest;
 import com.oneonone.userservice.presentation.dto.request.SignupRequest;
+import com.oneonone.userservice.presentation.dto.request.UpdateMasterRequest;
 import com.oneonone.userservice.presentation.dto.request.UpdateUserRequest;
 import com.oneonone.userservice.presentation.dto.response.LoginResponse;
 import com.oneonone.userservice.presentation.dto.response.SignupResponse;
@@ -101,5 +103,22 @@ public class UserController {
         if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
         MasterUserResponse response = userService.getUser(userId);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 조회 성공"));
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<ApiResponse<MasterUserResponse>> updateUser(
+            @RequestHeader("X-User-Role") String role,
+            @RequestBody UpdateMasterRequest request,
+            @PathVariable Long userId) {
+        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        UpdateMasterCommand command = new UpdateMasterCommand(
+                request.nickname(),
+                request.role(),
+                request.status(),
+                request.pointBalance(),
+                request.slackId()
+        );
+        MasterUserResponse response = userService.updateUser(userId, command);
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 정보 업데이트 성공"));
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<UserResponse>> updateMyProfile(
             @RequestHeader("X-User-Id") Long userId,
-            @RequestBody UpdateUserRequest request) {
+            @Valid @RequestBody UpdateUserRequest request) {
         UpdateUserCommand command = new UpdateUserCommand(
                 request.password(),
                 request.nickname(),

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -2,22 +2,13 @@ package com.oneonone.userservice.presentation;
 
 import com.oneonone.common.exception.BusinessException;
 import com.oneonone.common.response.ApiResponse;
-import com.oneonone.userservice.application.command.LoginCommand;
-import com.oneonone.userservice.application.command.SignupCommand;
-import com.oneonone.userservice.application.command.UpdateMasterCommand;
-import com.oneonone.userservice.application.command.UpdateUserCommand;
+import com.oneonone.userservice.application.command.*;
 import com.oneonone.userservice.application.service.AuthService;
 import com.oneonone.userservice.application.service.UserService;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.exception.UserErrorCode;
-import com.oneonone.userservice.presentation.dto.request.LoginRequest;
-import com.oneonone.userservice.presentation.dto.request.SignupRequest;
-import com.oneonone.userservice.presentation.dto.request.UpdateMasterRequest;
-import com.oneonone.userservice.presentation.dto.request.UpdateUserRequest;
-import com.oneonone.userservice.presentation.dto.response.LoginResponse;
-import com.oneonone.userservice.presentation.dto.response.SignupResponse;
-import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
-import com.oneonone.userservice.presentation.dto.response.UserResponse;
+import com.oneonone.userservice.presentation.dto.request.*;
+import com.oneonone.userservice.presentation.dto.response.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -130,5 +121,26 @@ public class UserController {
         if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
         userService.deleteByMaster(id, userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{userId}/points")
+    public ResponseEntity<ApiResponse<PointResponse>> getPoint(
+            @RequestHeader("X-User-Role") String role,
+            @PathVariable Long userId) {
+        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        PointResponse response = userService.getPoint(userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 조회 성공"));
+    }
+
+    @PatchMapping("/{userId}/points")
+    public ResponseEntity<ApiResponse<PointResponse>> updatePoint(
+            @RequestHeader("X-User-Role") String role,
+            @PathVariable Long userId,
+            @RequestBody PointRequest request) {
+        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        UpdatePointCommand command = new UpdatePointCommand(
+                request.amount());
+        PointResponse response = userService.updatePoint(userId, command);
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 수정 성공"));
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -1,5 +1,6 @@
 package com.oneonone.userservice.presentation;
 
+import com.oneonone.common.exception.BusinessException;
 import com.oneonone.common.response.ApiResponse;
 import com.oneonone.userservice.application.command.LoginCommand;
 import com.oneonone.userservice.application.command.SignupCommand;
@@ -7,14 +8,20 @@ import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.service.AuthService;
 import com.oneonone.userservice.application.service.UserService;
 import com.oneonone.userservice.domain.entity.User;
+import com.oneonone.userservice.exception.UserErrorCode;
 import com.oneonone.userservice.presentation.dto.request.LoginRequest;
 import com.oneonone.userservice.presentation.dto.request.SignupRequest;
 import com.oneonone.userservice.presentation.dto.request.UpdateUserRequest;
 import com.oneonone.userservice.presentation.dto.response.LoginResponse;
 import com.oneonone.userservice.presentation.dto.response.SignupResponse;
+import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -76,5 +83,14 @@ public class UserController {
             @RequestHeader("X-User-Id") Long userId) {
         userService.deleteMyProfile(userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<MasterUserResponse>>> getUserList(
+            @RequestHeader("X-User-Role") String role,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        Page<MasterUserResponse> response = userService.getAllUsers(pageable);
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 목록 조회 성공"));
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -1,5 +1,6 @@
 package com.oneonone.userservice.presentation;
 
+import com.oneonone.common.enums.UserRole;
 import com.oneonone.common.exception.BusinessException;
 import com.oneonone.common.response.ApiResponse;
 import com.oneonone.userservice.application.command.*;
@@ -82,7 +83,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<Page<MasterUserResponse>>> getUserList(
             @RequestHeader("X-User-Role") String role,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
         Page<MasterUserResponse> response = userService.getAllUsers(pageable);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 목록 조회 성공"));
     }
@@ -91,7 +92,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<MasterUserResponse>> getUserDetail(
             @RequestHeader("X-User-Role") String role,
             @PathVariable Long userId) {
-        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
         MasterUserResponse response = userService.getUser(userId);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 조회 성공"));
     }
@@ -101,7 +102,7 @@ public class UserController {
             @RequestHeader("X-User-Role") String role,
             @RequestBody UpdateMasterRequest request,
             @PathVariable Long userId) {
-        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
         UpdateMasterCommand command = new UpdateMasterCommand(
                 request.nickname(),
                 request.role(),
@@ -118,7 +119,7 @@ public class UserController {
             @RequestHeader("X-User-Id") Long id,
             @RequestHeader("X-User-Role") String role,
             @PathVariable Long userId) {
-        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
         userService.deleteByMaster(id, userId);
         return ResponseEntity.noContent().build();
     }
@@ -127,7 +128,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<PointResponse>> getPoint(
             @RequestHeader("X-User-Role") String role,
             @PathVariable Long userId) {
-        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
         PointResponse response = userService.getPoint(userId);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 조회 성공"));
     }
@@ -137,7 +138,7 @@ public class UserController {
             @RequestHeader("X-User-Role") String role,
             @PathVariable Long userId,
             @RequestBody PointRequest request) {
-        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
         UpdatePointCommand command = new UpdatePointCommand(
                 request.amount());
         PointResponse response = userService.updatePoint(userId, command);

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -121,4 +121,14 @@ public class UserController {
         MasterUserResponse response = userService.updateUser(userId, command);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 정보 업데이트 성공"));
     }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @RequestHeader("X-User-Id") Long id,
+            @RequestHeader("X-User-Role") String role,
+            @PathVariable Long userId) {
+        if (!role.equals("MASTER")) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        userService.deleteByMaster(id, userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -70,4 +70,11 @@ public class UserController {
         UserResponse response = userService.updateMyProfile(userId, command);
         return ResponseEntity.ok(ApiResponse.success(response, "내 정보 업데이트 성공"));
     }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMyProfile(
+            @RequestHeader("X-User-Id") Long userId) {
+        userService.deleteMyProfile(userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/PointRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/PointRequest.java
@@ -1,0 +1,6 @@
+package com.oneonone.userservice.presentation.dto.request;
+
+public record PointRequest(
+        Long amount
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateMasterRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateMasterRequest.java
@@ -1,0 +1,13 @@
+package com.oneonone.userservice.presentation.dto.request;
+
+import com.oneonone.common.enums.UserRole;
+import com.oneonone.userservice.domain.enums.UserStatus;
+
+public record UpdateMasterRequest(
+        String nickname,
+        UserRole role,
+        UserStatus status,
+        Long pointBalance,
+        String slackId
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateUserRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateUserRequest.java
@@ -1,0 +1,12 @@
+package com.oneonone.userservice.presentation.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateUserRequest(
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,15}$",
+                message = "비밀번호는 영문 대소문자와 숫자, 특수문자를 포함한 8~15자로 구성되어야 합니다.")
+        String password,
+        String nickname,
+        String slackId
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/MasterUserResponse.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/MasterUserResponse.java
@@ -4,7 +4,8 @@ import com.oneonone.common.enums.UserRole;
 import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.enums.UserStatus;
 
-public record UserResponse(
+public record MasterUserResponse(
+        Long userId,
         String username,
         String nickname,
         UserRole role,
@@ -12,13 +13,15 @@ public record UserResponse(
         Long pointBalance,
         String slackId
 ) {
-    public static UserResponse from(UserInfo userInfo) {
-        return new UserResponse(
+    public static MasterUserResponse from(UserInfo userInfo) {
+        return new MasterUserResponse(
+                userInfo.userId(),
                 userInfo.username(),
                 userInfo.nickname(),
                 userInfo.role(),
                 userInfo.status(),
                 userInfo.pointBalance(),
-                userInfo.slackId());
+                userInfo.slackId()
+        );
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/PointResponse.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/PointResponse.java
@@ -1,0 +1,14 @@
+package com.oneonone.userservice.presentation.dto.response;
+
+import com.oneonone.userservice.application.dto.UserInfo;
+
+public record PointResponse(
+        Long userId,
+        Long pointBalance
+) {
+    public static PointResponse from(UserInfo userInfo) {
+        return new PointResponse(
+                userInfo.userId(),
+                userInfo.pointBalance());
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #9 

## 📝 개요
- 기본적인 사용자 CRUD를 구현했습니다.
- 권한별 수정 범위 상이
- 일반 유저: 비밀번호, 닉네임, 슬랙 ID / 관리자: 닉네임, 역할, 상태, 포인트, 슬랙 ID
- 서비스 간 통신을 위한 `/api/v1/users/{userId}/points` API를 구현했습니다. (관리자 - 특정 유저의 포인트 조회 및 수정 가능)

## 🔁 변경 사항
- presentation의 DTO 생성 시 엔티티 대신 UserInfo 사용으로 수정했습니다.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타