### PR TITLE
[Feature] Outbox 패턴 적용을 통한 Balance 업데이트 및 Point 이벤트 Kafka 발행

### DIFF
--- a/point-service/src/main/java/com/oneonone/pointservice/application/command/CreatePointCommand.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/application/command/CreatePointCommand.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CreatePointCommand {
     private final PointType type;
-    private final int amount;
+    private final Long amount;
     private final String description;
     private final Long userId;
 }

--- a/point-service/src/main/java/com/oneonone/pointservice/application/service/PointService.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/application/service/PointService.java
@@ -21,7 +21,7 @@ public class PointService {
     private final PointRepository pointRepository;
 
     @Transactional
-    public Point createPoint(PointType type, int amount, String description, Long userId) {
+    public Point createPoint(PointType type, Long amount, String description, Long userId) {
         Point point = new Point(type, amount, description, userId);
         return pointRepository.save(point);
     }

--- a/point-service/src/main/java/com/oneonone/pointservice/domain/entity/Point.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/domain/entity/Point.java
@@ -37,6 +37,8 @@ public class Point extends BaseEntity {
     @Column(name="description")
     private String description;
 
+    private String betId;
+
     @Column(name="user_id", nullable=false)
     private Long userId;
 
@@ -53,22 +55,22 @@ public class Point extends BaseEntity {
     }
 
     public static Point create(
-            UUID eventId,
+            String eventId,
             Long userId,
             Long amount,
             PointType pointType,
-            String description
+            String betId
     ) {
         if (amount <= 0) {
             throw new BusinessException(PointErrorCode.INVALID_AMOUNT);
         }
 
         Point point = new Point();
-        point.eventId = eventId;
+        point.eventId = UUID.fromString(eventId);
         point.userId = userId;
         point.amount = amount;
         point.pointType = pointType;
-        point.description = description;
+        point.betId = betId;
         point.status = PointStatus.PENDING;
 
         return point;

--- a/point-service/src/main/java/com/oneonone/pointservice/domain/entity/Point.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/domain/entity/Point.java
@@ -20,6 +20,9 @@ public class Point extends BaseEntity {
     @Column(name="point_id")
     private UUID id;
 
+    @Column(name = "event_id", nullable = false, updatable = false)
+    private UUID eventId;   // Saga / Kafka 멱등성 키
+
     @Enumerated(EnumType.STRING)
     @Column(name="point_type", nullable=false)
     private PointType pointType;
@@ -29,7 +32,7 @@ public class Point extends BaseEntity {
     private PointStatus status;
 
     @Column(name="amount", nullable=false)
-    private int amount;
+    private Long amount;
 
     @Column(name="description")
     private String description;
@@ -38,7 +41,7 @@ public class Point extends BaseEntity {
     private Long userId;
 
     // Point 생성자 (도메인 규칙 적용)
-    public Point(PointType type, int amount, String description, Long userId) {
+    public Point(PointType type, Long amount, String description, Long userId) {
         if (amount <= 0) {
             throw new BusinessException(PointErrorCode.INVALID_AMOUNT);
         }
@@ -49,6 +52,45 @@ public class Point extends BaseEntity {
         this.status = PointStatus.PENDING;
     }
 
+    public static Point create(
+            UUID eventId,
+            Long userId,
+            Long amount,
+            PointType pointType,
+            String description
+    ) {
+        if (amount <= 0) {
+            throw new BusinessException(PointErrorCode.INVALID_AMOUNT);
+        }
+
+        Point point = new Point();
+        point.eventId = eventId;
+        point.userId = userId;
+        point.amount = amount;
+        point.pointType = pointType;
+        point.description = description;
+        point.status = PointStatus.PENDING;
+
+        return point;
+    }
+
+    public void markSuccess() {
+        validateUpdatable();
+        this.status = PointStatus.SUCCESS;
+    }
+
+    public void markFailed() {
+        validateUpdatable();
+        this.status = PointStatus.FAILED;
+    }
+
+    private void validateUpdatable(){
+        if(this.status == PointStatus.SUCCESS){
+            throw new BusinessException(PointErrorCode.STATUS_CANNOT_CHANGE);
+        }
+    }
+
+    // todo: 이부분이 없어져야할수도 있음. 그러면 update api부분은 어떻게 처리할 것인가?
     public void changeStatus(PointStatus newStatus) {
         if (this.status == PointStatus.SUCCESS) {
             throw new BusinessException(PointErrorCode.STATUS_CANNOT_CHANGE);

--- a/point-service/src/main/java/com/oneonone/pointservice/domain/repository/PointRepository.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/domain/repository/PointRepository.java
@@ -13,4 +13,5 @@ public interface PointRepository {
     Optional<Point> findById(UUID pointId);
     Page<Point> findByUserId(Long userId, Pageable pageable);
     Page<Point> findByUserIdAndStatus(Long userId, PointStatus status, Pageable pageable);
+    boolean existsByEventId(UUID eventId);
 }

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/KafkaConfig.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/KafkaConfig.java
@@ -1,0 +1,64 @@
+package com.oneonone.pointservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    private static final String BOOTSTRAP_SERVERS = "localhost:9092";
+
+    // Producer (PointService에서는 보통 안쓰지만, 테스트용)
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Consumer 설정
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "point-service");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // JSON 역직렬화 허용
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    // ObjectMapper Bean
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/consumer/BalanceEventConsumer.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/consumer/BalanceEventConsumer.java
@@ -1,0 +1,59 @@
+package com.oneonone.pointservice.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneonone.pointservice.domain.entity.Point;
+import com.oneonone.pointservice.domain.enums.PointType;
+import com.oneonone.pointservice.domain.repository.PointRepository;
+import com.oneonone.pointservice.infrastructure.kafka.dto.BalanceEventPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// class 이름은 발생한 event를 따라감
+@Component
+@RequiredArgsConstructor
+public class BalanceEventConsumer {
+    private final PointRepository pointRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "point-update-event",
+            groupId = "point-service"
+    )
+
+    @Transactional
+    public void consume(String payloadJson){
+        try {
+            // Json 역직렬화
+            BalanceEventPayload payload = objectMapper.readValue(payloadJson, BalanceEventPayload.class);
+
+            // 중복 이벤트 처리 방지
+            if (pointRepository.existsByEventId(payload.eventId())) {
+                return;
+            }
+
+            // 타입 검증
+            PointType pointType;
+            try {
+                pointType = PointType.valueOf(payload.type());
+            } catch (IllegalArgumentException e) {
+                // 잘못된 type 들어왔을 때 로깅 후 종료
+                System.err.println("Invalid PointType: " + payload.type());
+                return;
+            }
+
+            // 포인트 생성 후 저장
+            Point point = Point.create(
+                    payload.eventId(),
+                    payload.userId(),
+                    payload.amount(),
+                    pointType,
+                    payload.description()
+            );
+            pointRepository.save(point);
+        } catch (Exception e) {
+            System.err.println("Failed to consume payload: " + e.getMessage());
+        }
+    }
+}

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/consumer/BalanceEventConsumer.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/consumer/BalanceEventConsumer.java
@@ -10,6 +10,8 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 // class 이름은 발생한 event를 따라감
 @Component
 @RequiredArgsConstructor
@@ -29,7 +31,7 @@ public class BalanceEventConsumer {
             BalanceEventPayload payload = objectMapper.readValue(payloadJson, BalanceEventPayload.class);
 
             // 중복 이벤트 처리 방지
-            if (pointRepository.existsByEventId(payload.eventId())) {
+            if (pointRepository.existsByEventId(UUID.fromString(payload.eventId()))) {
                 return;
             }
 
@@ -49,9 +51,10 @@ public class BalanceEventConsumer {
                     payload.userId(),
                     payload.amount(),
                     pointType,
-                    payload.description()
+                    payload.betId()
             );
             pointRepository.save(point);
+            point.markSuccess();
         } catch (Exception e) {
             System.err.println("Failed to consume payload: " + e.getMessage());
         }

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/dto/BalanceEventPayload.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/dto/BalanceEventPayload.java
@@ -1,0 +1,11 @@
+package com.oneonone.pointservice.infrastructure.kafka.dto;
+
+import java.util.UUID;
+
+public record BalanceEventPayload (
+        Long userId,
+        Long amount,
+        String type,
+        UUID eventId,
+        String description
+) {}

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/dto/BalanceEventPayload.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/kafka/dto/BalanceEventPayload.java
@@ -1,11 +1,10 @@
 package com.oneonone.pointservice.infrastructure.kafka.dto;
 
-import java.util.UUID;
-
 public record BalanceEventPayload (
+        String eventId,
         Long userId,
         Long amount,
-        String type,
-        UUID eventId,
-        String description
+        String type,   // CREDIT / DEBIT
+        String betId     // nullable
 ) {}
+

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/repository/PointJpaRepository.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/repository/PointJpaRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface PointJpaRepository extends JpaRepository<Point, UUID> {
     Page<Point> findByUserId(Long userId, Pageable pageable);
     Page<Point> findByUserIdAndStatus(Long userId, PointStatus status, Pageable pageable);
+    boolean existsByEventId(UUID eventId);
 }

--- a/point-service/src/main/java/com/oneonone/pointservice/infrastructure/repository/PointRepositoryImpl.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/infrastructure/repository/PointRepositoryImpl.java
@@ -36,4 +36,9 @@ public class PointRepositoryImpl implements PointRepository {
     public Page<Point> findByUserIdAndStatus(Long userId, PointStatus pointStatus, Pageable pageable) {
         return pointJpaRepository.findByUserIdAndStatus(userId, pointStatus, pageable);
     }
+
+    @Override
+    public boolean existsByEventId(UUID eventId) {
+        return pointJpaRepository.existsByEventId(eventId);
+    }
 }

--- a/point-service/src/main/java/com/oneonone/pointservice/presentation/dto/request/CreatePointRequest.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/presentation/dto/request/CreatePointRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreatePointRequest {
     private PointType pointType;
-    private int amount;
+    private Long amount;
     private String description;
     private Long userId;
 }

--- a/point-service/src/main/java/com/oneonone/pointservice/presentation/dto/response/PointResponse.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/presentation/dto/response/PointResponse.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public class PointResponse {
     private UUID pointId;
     private PointType type;
-    private int amount;
+    private Long amount;
     private String description;
     private PointStatus status;
     private Long userId;

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
@@ -3,9 +3,12 @@ package com.oneonone.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class UserServiceApplication {
 
     public static void main(String[] args) {

--- a/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
@@ -3,7 +3,6 @@ package com.oneonone.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication

--- a/user-service/src/main/java/com/oneonone/userservice/application/command/UpdateBalanceCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/UpdateBalanceCommand.java
@@ -1,0 +1,10 @@
+package com.oneonone.userservice.application.command;
+
+import java.util.UUID;
+
+public record UpdateBalanceCommand(
+        Long amount,      // 차감/추가 금액
+        String type,      // "DEBIT" 또는 "CREDIT"
+        UUID eventId,     // 멱등성 키
+        UUID betId
+) {}

--- a/user-service/src/main/java/com/oneonone/userservice/application/scheduler/OutboxEventPoller.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/scheduler/OutboxEventPoller.java
@@ -1,0 +1,74 @@
+package com.oneonone.userservice.application.scheduler;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneonone.userservice.domain.entity.OutboxEvent;
+import com.oneonone.userservice.domain.repository.OutboxRepository;
+import com.oneonone.userservice.infrastructure.kafka.UserKafkaProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPoller {
+
+    private static final int BATCH_SIZE = 100;
+
+    private final OutboxRepository outboxRepository;
+    private final UserKafkaProducer kafkaProducer;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 일정 주기로 처리되지 않은 Outbox 이벤트를 조회하여 Kafka로 발행한다.
+     * - Kafka 발행 성공 시에만 processed=true 처리
+     * - 실패 시 재시도를 위해 processed=false 유지
+     */
+    @Scheduled(fixedDelay = 1000) // 1초마다 실행
+    @Transactional
+    public void pollAndPublish() {
+        List<OutboxEvent> events =
+                outboxRepository.findUnprocessedEvents(BATCH_SIZE);
+
+        if (events.isEmpty()) {
+            return;
+        }
+
+        for (OutboxEvent event : events) {
+            if (!event.canRetry()) {
+                event.markAsFailed();
+                outboxRepository.save(event);
+                log.error("[OUTBOX-POLLER] Max retries exceeded: eventId = {}, userId = {}", event.getEventId(), event.getUserId());
+                return;
+            }
+            try {
+                // send(비동기) 쓰면 응답 기다리지 않고 바로 처리 -> 유실 가능 BUT 대부분 성공
+                // sendSync(동기) 쓰면 응답 -> 신뢰성 있는 메시지 전송 가능 BUT 느림
+                // 포인트(중요 정보)라 동기 처리 해야할 것 같긴 한데 일단 성능 비교 해봣을 때 크게 차이 안 나면 그냥 sendSync로 진행해도 될 것 같아요
+                kafkaProducer.sendSync(event.toBalanceEventPayload(objectMapper));
+                event.markAsSuccess();
+                log.info(
+                        "[OUTBOX-SENT] eventId={}, userId={}",
+                        event.getEventId(),
+                        event.getUserId()
+                );
+                outboxRepository.save(event);
+            } catch (Exception e) {
+                // ❗ 실패 시 processed=false 유지 (재시도 대상)
+                log.error(
+                        "[OUTBOX-FAILED] eventId={}, reason={}",
+                        event.getEventId(),
+                        e.getMessage(),
+                        e
+                );
+                event.increaseRetry();
+                outboxRepository.save(event);
+            }
+        }
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/scheduler/OutboxEventPoller.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/scheduler/OutboxEventPoller.java
@@ -29,7 +29,7 @@ public class OutboxEventPoller {
      * - Kafka 발행 성공 시에만 processed=true 처리
      * - 실패 시 재시도를 위해 processed=false 유지
      */
-    @Scheduled(fixedDelay = 1000) // 1초마다 실행
+    @Scheduled(fixedDelay = 5000) // 5초마다 실행
     @Transactional
     public void pollAndPublish() {
         List<OutboxEvent> events =

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -1,16 +1,17 @@
 package com.oneonone.userservice.application.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneonone.common.exception.BusinessException;
-import com.oneonone.userservice.application.command.SignupCommand;
-import com.oneonone.userservice.application.command.UpdateMasterCommand;
-import com.oneonone.userservice.application.command.UpdatePointCommand;
-import com.oneonone.userservice.application.command.UpdateUserCommand;
+import com.oneonone.userservice.application.command.*;
 import com.oneonone.userservice.application.dto.UserInfo;
+import com.oneonone.userservice.domain.entity.OutboxEvent;
 import com.oneonone.userservice.domain.entity.User;
+import com.oneonone.userservice.domain.repository.OutboxRepository;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
 import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
-import com.oneonone.userservice.presentation.dto.response.PointResponse;
+import com.oneonone.userservice.presentation.dto.response.BalanceResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,12 +20,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public User signUp(SignupCommand command) {
@@ -102,22 +109,58 @@ public class UserService {
         user.softDelete(id);
     }
 
-    public PointResponse getPoint(Long userId) {
+    public BalanceResponse getPoint(Long userId) {
         User user = findUserById(userId);
         UserInfo userInfo = UserInfo.from(user);
-        return PointResponse.from(userInfo);
+        return BalanceResponse.from(userInfo);
     }
 
-    @Transactional
-    public PointResponse updatePoint(Long userId, UpdatePointCommand command) {
-        User user = findUserById(userId);
-        user.updatePoint(command.amount());
-        UserInfo userInfo = UserInfo.from(user);
-        return PointResponse.from(userInfo);
-    }
+//    @Transactional
+//    public BalanceResponse updatePoint(Long userId, UpdatePointCommand command) {
+//        User user = findUserById(userId);
+//        user.updatePoint(command.amount());
+//        UserInfo userInfo = UserInfo.from(user);
+//        return BalanceResponse.from(userInfo);
+//    }
 
     private User findUserById(Long userId) {
         return userRepository.findByUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional // <- 이 부분 추가했어여
+    public BalanceResponse updateBalance(Long userId, UpdateBalanceCommand command) {
+        User user = findUserById(userId);
+
+        // Balance 업데이트
+        // 성능 개선을 위해 락 없이 먼저 구현, 나중에 낙관적/비관적 락 구현
+        user.updateBalance(command.amount(), command.type());
+
+        // 3. Outbox payload 생성
+        Map<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("userId", userId);
+        payloadMap.put("amount", command.amount());
+        payloadMap.put("type", command.type());
+        payloadMap.put("eventId", command.eventId());
+        if (command.betId() != null) {
+            payloadMap.put("betId", command.betId());
+        }
+
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsString(payloadMap);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(UserErrorCode.OUTBOX_PAYLOAD_ERROR);
+        }
+
+        // outbox 이벤트 생성 및 저장
+        OutboxEvent outboxEvent = new OutboxEvent(
+                command.eventId(),
+                userId,
+                payload
+        );
+        outboxRepository.save(outboxEvent);
+
+        return new BalanceResponse(userId, user.getPointBalance());
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -3,26 +3,29 @@ package com.oneonone.userservice.application.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneonone.common.exception.BusinessException;
-import com.oneonone.userservice.application.command.*;
+import com.oneonone.userservice.application.command.SignupCommand;
+import com.oneonone.userservice.application.command.UpdateBalanceCommand;
+import com.oneonone.userservice.application.command.UpdateMasterCommand;
+import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.OutboxEvent;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.OutboxRepository;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
-import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
+import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
 import com.oneonone.userservice.presentation.dto.response.BalanceResponse;
+import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -135,21 +138,31 @@ public class UserService {
         // Balance 업데이트
         // 성능 개선을 위해 락 없이 먼저 구현, 나중에 낙관적/비관적 락 구현
         user.updateBalance(command.amount(), command.type());
+//
+//        // 3. Outbox payload 생성
+//        Map<String, Object> payloadMap = new HashMap<>();
+//        payloadMap.put("userId", userId);
+//        payloadMap.put("amount", command.amount());
+//        payloadMap.put("type", command.type());
+//        payloadMap.put("eventId", command.eventId());
+//        if (command.betId() != null) {
+//            payloadMap.put("betId", command.betId());
+//        }
 
-        // 3. Outbox payload 생성
-        Map<String, Object> payloadMap = new HashMap<>();
-        payloadMap.put("userId", userId);
-        payloadMap.put("amount", command.amount());
-        payloadMap.put("type", command.type());
-        payloadMap.put("eventId", command.eventId());
-        if (command.betId() != null) {
-            payloadMap.put("betId", command.betId());
-        }
+        BalanceEventPayload payloadDTO = new BalanceEventPayload(
+                command.eventId().toString(),
+                userId,
+                command.amount(),
+                command.type(),
+                command.betId().toString()
+        );
 
         String payload;
         try {
-            payload = objectMapper.writeValueAsString(payloadMap);
+            payload = objectMapper.writeValueAsString(payloadDTO);
+            log.info("[BALANCE-UPDATE] Created payload: {}", payload);
         } catch (JsonProcessingException e) {
+            log.error("[BALANCE-UPDATE] Failed to serialize payload: {}", e);
             throw new BusinessException(UserErrorCode.OUTBOX_PAYLOAD_ERROR);
         }
 

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/OutboxEvent.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/OutboxEvent.java
@@ -1,0 +1,85 @@
+package com.oneonone.userservice.domain.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneonone.userservice.domain.enums.OutboxStatus;
+import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
+import jakarta.persistence.*;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Entity
+@Table(name = "p_outboxes")
+@Getter
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID outboxId;
+
+    @Column(nullable = false, unique = true)
+    private UUID eventId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    // processed 부분 Enum으로 변경했습니다
+    private OutboxStatus status = OutboxStatus.PENDING;
+
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private String payload;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime publishedAt;
+
+    @Column(nullable = false)
+    private Integer retryCount = 0;
+
+    protected OutboxEvent() {}
+
+    public OutboxEvent(UUID eventId, Long userId, String payload) {
+        this.eventId = eventId;
+        this.userId = userId;
+        this.payload = payload;
+    }
+
+    @PrePersist
+    protected void create() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markAsSuccess() {
+        this.status = OutboxStatus.SUCCESS;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+
+    public void increaseRetry() {
+        this.retryCount++;
+    }
+
+    public boolean canRetry() {
+        return this.status == OutboxStatus.PENDING && this.retryCount < 3;
+    }
+
+
+    /**
+     * JSON payload를 BalanceEventPayload DTO로 변환
+     */
+    public BalanceEventPayload toBalanceEventPayload(ObjectMapper objectMapper) {
+        try {
+            return objectMapper.readValue(this.payload, BalanceEventPayload.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("OutboxEvent JSON -> DTO 변환 실패", e);
+        }
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/OutboxEvent.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/OutboxEvent.java
@@ -6,6 +6,10 @@ import com.oneonone.userservice.domain.enums.OutboxStatus;
 import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -30,6 +34,7 @@ public class OutboxEvent {
     // processed 부분 Enum으로 변경했습니다
     private OutboxStatus status = OutboxStatus.PENDING;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb", nullable = false)
     private String payload;
 

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/OutboxEvent.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/OutboxEvent.java
@@ -6,7 +6,6 @@ import com.oneonone.userservice.domain.enums.OutboxStatus;
 import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
@@ -87,9 +87,17 @@ public class User extends BaseEntity {
         if (slackId != null) this.slackId = slackId;
     }
 
-    public void updatePoint(Long amount) {
-        if (this.pointBalance + amount < 0) throw new BusinessException(UserErrorCode.INVALID_POINT);
-        this.pointBalance += amount;
+    public void updateBalance(Long amount, String type) {
+        if ("DEBIT".equalsIgnoreCase(type)) {
+            if (this.pointBalance - amount < 0) {
+                throw new BusinessException(UserErrorCode.INVALID_POINT);
+            }
+            this.pointBalance -= amount;
+        } else if ("CREDIT".equalsIgnoreCase(type)) {
+            this.pointBalance += amount;
+        } else {
+            throw new BusinessException(UserErrorCode.INVALID_POINT_TYPE);
+        }
     }
 
     public void validate(String nickname) {

--- a/user-service/src/main/java/com/oneonone/userservice/domain/enums/OutboxStatus.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/enums/OutboxStatus.java
@@ -1,0 +1,5 @@
+package com.oneonone.userservice.domain.enums;
+
+public enum OutboxStatus {
+    PENDING, SUCCESS, FAILED
+}

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/OutboxRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/OutboxRepository.java
@@ -1,0 +1,17 @@
+package com.oneonone.userservice.domain.repository;
+
+import com.oneonone.userservice.domain.entity.OutboxEvent;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OutboxRepository {
+
+    OutboxEvent save(OutboxEvent event);
+
+    boolean existsByEventId(UUID eventId);
+
+    List<OutboxEvent> findUnprocessedEvents(int limit);
+
+    Optional<OutboxEvent> findByEventId(UUID eventId);
+}

--- a/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
@@ -14,7 +14,10 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "U003", "비밀번호가 일치하지 않습니다."),
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "U004", "사용할 수 없는 닉네임입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "U005", "접근 권한이 없습니다."),
-    INVALID_POINT(HttpStatus.BAD_REQUEST, "U006", "포인트는 음수가 될 수 없습니다.");
+    INVALID_POINT(HttpStatus.BAD_REQUEST, "U006", "포인트는 음수가 될 수 없습니다."),
+    INVALID_POINT_TYPE(HttpStatus.BAD_REQUEST, "U007", "포인트 타입은 DEBIT 또는 CREDIT이어야 합니다."),
+    OUTBOX_PAYLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "U008", "Outbox payload 생성에 실패했습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/KafkaConfig.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/KafkaConfig.java
@@ -1,0 +1,60 @@
+package com.oneonone.userservice.infrastructure.kafka;
+
+import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    private static final String BOOTSTRAP_SERVERS = "localhost:9092";
+
+    // Producer 설정
+    @Bean
+    public ProducerFactory<String, BalanceEventPayload> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, BalanceEventPayload> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Consumer 설정
+    @Bean
+    public ConsumerFactory<String, BalanceEventPayload> consumerFactory() {
+        JsonDeserializer<BalanceEventPayload> deserializer = new JsonDeserializer<>(BalanceEventPayload.class);
+        deserializer.addTrustedPackages("*");
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, "point-service");
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, BalanceEventPayload> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, BalanceEventPayload> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/UserKafkaProducer.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/UserKafkaProducer.java
@@ -1,0 +1,37 @@
+package com.oneonone.userservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserKafkaProducer {
+
+    private static final String TOPIC = "point-update-event";
+
+    private final KafkaTemplate<String, BalanceEventPayload> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 비동기 전송
+    public void send(BalanceEventPayload payload) {
+            kafkaTemplate.send(TOPIC, payload.userId().toString(), payload);
+            log.debug("[KAFKA-SEND] topic={}, key={}", TOPIC, payload.userId());
+
+    }
+
+    public void sendSync(BalanceEventPayload payload) throws ExecutionException, InterruptedException, TimeoutException {
+            kafkaTemplate.send(TOPIC, payload.userId().toString(), payload)
+                    .get(5, TimeUnit.SECONDS);
+            log.debug("[KAFKA-SEND-SYNC] topic={}, userId={}", TOPIC, payload.userId());
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/UserKafkaProducer.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/UserKafkaProducer.java
@@ -1,6 +1,5 @@
 package com.oneonone.userservice.infrastructure.kafka;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneonone.userservice.infrastructure.kafka.dto.BalanceEventPayload;
 import lombok.RequiredArgsConstructor;

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/dto/BalanceEventPayload.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/dto/BalanceEventPayload.java
@@ -1,12 +1,10 @@
 package com.oneonone.userservice.infrastructure.kafka.dto;
 
-import java.util.UUID;
-
 public record BalanceEventPayload(
-        UUID eventId,
+        String eventId,
         Long userId,
         Long amount,
         String type,   // CREDIT / DEBIT
-        Long betId     // nullable
+        String betId     // nullable
 ) {
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/dto/BalanceEventPayload.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/dto/BalanceEventPayload.java
@@ -1,0 +1,12 @@
+package com.oneonone.userservice.infrastructure.kafka.dto;
+
+import java.util.UUID;
+
+public record BalanceEventPayload(
+        UUID eventId,
+        Long userId,
+        Long amount,
+        String type,   // CREDIT / DEBIT
+        Long betId     // nullable
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/OutboxJpaRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/OutboxJpaRepository.java
@@ -1,0 +1,18 @@
+package com.oneonone.userservice.infrastructure.repository;
+
+import com.oneonone.userservice.domain.entity.OutboxEvent;
+import com.oneonone.userservice.domain.enums.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    boolean existsByEventId(UUID eventId);
+
+    Optional<OutboxEvent> findByEventId(UUID eventId);
+
+    List<OutboxEvent> findTop100ByStatusOrderByOutboxIdAsc(OutboxStatus status);
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/OutboxRepositoryImpl.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/OutboxRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.oneonone.userservice.infrastructure.repository;
+
+import com.oneonone.userservice.domain.entity.OutboxEvent;
+import com.oneonone.userservice.domain.enums.OutboxStatus;
+import com.oneonone.userservice.domain.repository.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public OutboxEvent save(OutboxEvent event) {
+        return outboxJpaRepository.save(event);
+    }
+
+    @Override
+    public boolean existsByEventId(UUID eventId) {
+        return outboxJpaRepository.existsByEventId(eventId);
+    }
+
+    @Override
+    public Optional<OutboxEvent> findByEventId(UUID eventId) {
+        return outboxJpaRepository.findByEventId(eventId);
+    }
+
+    @Override
+    public List<OutboxEvent> findUnprocessedEvents(int limit) {
+        // limit은 일단 100으로 고정 (추후 파라미터화 가능)
+        return outboxJpaRepository.findTop100ByStatusOrderByOutboxIdAsc(OutboxStatus.PENDING);
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -20,6 +20,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -124,24 +126,27 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/{userId}/points")
-    public ResponseEntity<ApiResponse<PointResponse>> getPoint(
+    @GetMapping("/{userId}/balance")
+    public ResponseEntity<ApiResponse<BalanceResponse>> getBalance(
             @RequestHeader("X-User-Role") String role,
             @PathVariable Long userId) {
         if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
-        PointResponse response = userService.getPoint(userId);
+        BalanceResponse response = userService.getPoint(userId);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 조회 성공"));
     }
 
-    @PatchMapping("/{userId}/points")
-    public ResponseEntity<ApiResponse<PointResponse>> updatePoint(
+    @PatchMapping("/{userId}/balance")
+    public ResponseEntity<ApiResponse<BalanceResponse>> updateBalance(
             @RequestHeader("X-User-Role") String role,
-            @PathVariable Long userId,
-            @RequestBody PointRequest request) {
-        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
-        UpdatePointCommand command = new UpdatePointCommand(
-                request.amount());
-        PointResponse response = userService.updatePoint(userId, command);
-        return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 수정 성공"));
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody UpdateBalanceRequest request) {
+//        if (!UserRole.valueOf(role).equals(UserRole.MASTER)) throw new BusinessException(UserErrorCode.FORBIDDEN);
+        UpdateBalanceCommand command = new UpdateBalanceCommand(
+                request.amount(),
+                request.type(),
+                request.eventId(),
+                UUID.fromString("11111111-1111-1111-1111-111111111111")); // 임의의 random UUID
+        BalanceResponse response = userService.updateBalance(userId, command);
+        return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 밸런스 수정 성공"));
     }
 }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateBalanceRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateBalanceRequest.java
@@ -1,0 +1,9 @@
+package com.oneonone.userservice.presentation.dto.request;
+
+import java.util.UUID;
+
+public record UpdateBalanceRequest(
+        Long amount,      // 차감/추가 금액
+        String type,      // "DEBIT" 또는 "CREDIT"
+        UUID eventId      // 멱등성 키
+) {}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/BalanceResponse.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/BalanceResponse.java
@@ -2,12 +2,12 @@ package com.oneonone.userservice.presentation.dto.response;
 
 import com.oneonone.userservice.application.dto.UserInfo;
 
-public record PointResponse(
+public record BalanceResponse(
         Long userId,
         Long pointBalance
 ) {
-    public static PointResponse from(UserInfo userInfo) {
-        return new PointResponse(
+    public static BalanceResponse from(UserInfo userInfo) {
+        return new BalanceResponse(
                 userInfo.userId(),
                 userInfo.pointBalance());
     }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -6,7 +6,11 @@ spring:
     name: user-service
   config:
     import: "configserver:"
-
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 eureka:
   client:
@@ -14,3 +18,4 @@ eureka:
       defaultZone: http://localhost:8761/eureka
     register-with-eureka: true
     fetch-registry: true
+


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #25

## 📝 개요
- Betting 요청 시 User.balance 업데이트와 Point 이벤트 발행을 Outbox 패턴으로 보장하기 위한 기능을 구현했습니다.
- Balance 변경과 이벤트 기록을 동일 트랜잭션에서 처리하여 정합성을 확보하고,
- Kafka를 통해 Point 서비스에 append-only 이벤트 로그를 전달합니다.

## 🔁 변경 사항
1. User 서비스
- User.balance 업데이트 API 구현
- 배팅 금액 차감/추가 로직 구현
- Outbox 테이블 추가
  - Balance 변경 이벤트 기록
  - event_id 기반 멱등성 키 저장
2. Outbox → Kafka 발행 프로세스
  - 주기적으로 Outbox 테이블을 조회하여 미발행 이벤트 Kafka 발행
  - 발행 성공 시 Outbox 상태 업데이트
  - Kafka 발행 실패 시 재시도 로직 적용
3. Point 서비스
  - Kafka Consumer 구현
  - 수신한 이벤트를 append-only 로그 형태로 저장
  
<img width="937" height="538" alt="image" src="https://github.com/user-attachments/assets/d896b8c9-0cb5-44e4-8167-63fce0203bb6" />
<img width="872" height="146" alt="image" src="https://github.com/user-attachments/assets/9b7f097e-3613-43e7-a5a1-02493eeddfad" />
<img width="905" height="98" alt="image" src="https://github.com/user-attachments/assets/92671556-4282-4b6d-9c7f-e44580276076" />


## 👀 참고 사항
- PR은 Outbox 패턴 적용을 우선으로 하며, Saga는 서비스 간 보상 트랜잭션 확장 시점에 적용 예정입니다.
- Point 서비스는 balance 변경과 완전히 독립적이며, 이벤트 기반으로만 동작합니다.

## 👀 기타
패턴 적용 요약
- Outbox: User 서비스 내 balance 업데이트와 이벤트 기록 정합성 보장
- Kafka: Point 서비스로 이벤트 전달
- 멱등성: event_id 기반 중복 처리 방지

이후 개선 사항
- Saga 기반 보상 트랜잭션 적용
- Redis 캐시 도입 후 성능 비교 테스트