### PR TITLE
[Feat] DLT 메시지 수신 시 Slack 알림

### DIFF
--- a/config-server/src/main/resources/config-repo/application.yml
+++ b/config-server/src/main/resources/config-repo/application.yml
@@ -18,3 +18,6 @@ eureka:
       defaultZone: http://localhost:8761/eureka
     register-with-eureka: true
     fetch-registry: true
+
+slack:
+  web-hook-url: ${SLACK_WEBHOOK_URL}

--- a/point-service/src/main/java/com/oneonone/pointservice/domain/repository/PointRepository.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/domain/repository/PointRepository.java
@@ -19,6 +19,5 @@ public interface PointRepository {
     Optional<Point> findByEventId(UUID eventId);
     // Saga 추적 (sagaId 기반)
     List<Point> findBySagaId(UUID sagaId);
-
     boolean existsByBetId(String betId);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestTemplate;
 
 @OpenAPIDefinition(
         servers = {
@@ -20,6 +22,11 @@ public class UserServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(UserServiceApplication.class, args);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 
 }

--- a/user-service/src/main/java/com/oneonone/userservice/application/event/BalanceEventPayload.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/event/BalanceEventPayload.java
@@ -1,0 +1,13 @@
+package com.oneonone.userservice.application.event;
+
+import com.oneonone.common.enums.PointType;
+
+public record BalanceEventPayload (
+        String sagaId,
+        String eventId,
+        Long userId,
+        Long amount,
+        PointType type,
+        String betId
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -8,12 +8,12 @@ import com.oneonone.userservice.application.command.UpdateBalanceCommand;
 import com.oneonone.userservice.application.command.UpdateMasterCommand;
 import com.oneonone.userservice.application.command.UpdateUserCommand;
 import com.oneonone.userservice.application.dto.UserInfo;
+import com.oneonone.userservice.application.event.BalanceEventPayload;
 import com.oneonone.userservice.domain.entity.OutboxEvent;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.repository.OutboxRepository;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
-import com.oneonone.userservice.infrastructure.kafka.event.BalanceEvent;
 import com.oneonone.userservice.presentation.dto.response.BalanceResponse;
 import com.oneonone.userservice.presentation.dto.response.MasterUserResponse;
 import com.oneonone.userservice.presentation.dto.response.UserResponse;
@@ -23,7 +23,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -152,8 +151,8 @@ public class UserService {
         user.updateBalance(command.amount(), command.type());
         log.info("업데이트 완료");
         // Outbox payload 생성
-        BalanceEvent event = new BalanceEvent(
-                command.sagaId().toString(),     // ✅ sagaId
+        BalanceEventPayload event = new BalanceEventPayload(
+                command.sagaId().toString(),
                 command.eventId().toString(),
                 userId,
                 command.amount(),

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/config/KafkaConfig.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/config/KafkaConfig.java
@@ -32,6 +32,7 @@ public class KafkaConfig {
     @Bean
     public ProducerFactory<String, Object> dltProducerFactory() {
         Map<String, Object> configProps = new HashMap<>();
+//        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:29092");
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
@@ -43,10 +44,33 @@ public class KafkaConfig {
         return new KafkaTemplate<>(dltProducerFactory());
     }
 
+    // DLT Consumer
+    @Bean
+    public ConsumerFactory<String, BettingEvent> dltConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+//        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:29092");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "user-service.dlt");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.oneonone.*");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, BettingEvent.class.getName());
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, BettingEvent> dltKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, BettingEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(dltConsumerFactory());
+        return factory;
+    }
+
     // BettingEvent Consumer
     @Bean
     public ConsumerFactory<String, BettingEvent> bettingEventConsumerFactory() {
         Map<String, Object> configProps = new HashMap<>();
+//        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:29092");
         configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "user-service");
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BettingConsumer.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BettingConsumer.java
@@ -61,7 +61,7 @@ public class BettingConsumer {
             );
             String payload = objectMapper.writeValueAsString(balanceEvent);
             OutboxEvent outboxEvent = new OutboxEvent(
-                    UUID.fromString(sagaId),
+                    UUID.fromString(sagaId), // TODO: DLT TEST -> null 처리
                     UUID.fromString(event.eventId()),
                     event.userId(),
                     payload

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BettingConsumer.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BettingConsumer.java
@@ -1,14 +1,17 @@
 
 package com.oneonone.userservice.infrastructure.kafka.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneonone.common.enums.PointType;
 import com.oneonone.common.exception.BusinessException;
+import com.oneonone.userservice.domain.entity.OutboxEvent;
 import com.oneonone.userservice.domain.entity.User;
+import com.oneonone.userservice.domain.repository.OutboxRepository;
 import com.oneonone.userservice.domain.repository.UserRepository;
 import com.oneonone.userservice.exception.UserErrorCode;
 import com.oneonone.userservice.infrastructure.kafka.event.BalanceEvent;
 import com.oneonone.userservice.infrastructure.kafka.event.BettingEvent;
-import com.oneonone.userservice.infrastructure.kafka.producer.UserKafkaProducer;
 import com.oneonone.userservice.infrastructure.persistence.entity.ProcessedBettingEvent;
 import com.oneonone.userservice.infrastructure.persistence.repository.ProcessedBettingEventRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +29,8 @@ public class BettingConsumer {
 
     private final UserRepository userRepository;
     private final ProcessedBettingEventRepository processedBettingEventRepository;
-    private final UserKafkaProducer userKafkaProducer;
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
 
     @KafkaListener(
             topics = "${spring.kafka.topics.betting-reward}",
@@ -34,28 +38,37 @@ public class BettingConsumer {
             containerFactory = "bettingEventConcurrentKafkaListenerContainerFactory"
     )
     @Transactional
-    public void consume(BettingEvent event) {
+    public void consume(BettingEvent event) throws JsonProcessingException {
         log.info("[KAFKA-CONSUME] [Betting] Received eventId={}, userId={}: ", event.eventId(), event.userId());
-        if (processedBettingEventRepository.existsByBetId(UUID.fromString(event.betId()))) {
+        if (processedBettingEventRepository.existsByEventId(UUID.fromString(event.eventId()))) {
             log.warn("[KAFKA-CONSUME] [Betting] Already processed eventId={}", event.eventId());
             return;
         }
-        processedBettingEventRepository.save(ProcessedBettingEvent.of(UUID.fromString(event.eventId()), event.userId(), UUID.fromString(event.betId()), event.amount()));
         try {
             User user = userRepository.findByUserIdAndDeletedAtIsNull(event.userId())
                     .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
             log.info("[KAFKA-CONSUME] [Betting] PointBalance Before Update for userId={}, pointBalance={}", user.getUserId(), user.getPointBalance());
             user.updateBalance(event.amount(), PointType.CREDIT);
             log.info("[KAFKA-CONSUME] [Betting] PointBalance After Update userId={}, pointBalance={}", user.getUserId(), user.getPointBalance());
+            String sagaId = UUID.randomUUID().toString(); // TODO: 임시 sagaId
             BalanceEvent balanceEvent = new BalanceEvent(
-                    UUID.randomUUID().toString(),
+                    sagaId, // TODO: Betting에서 받아오도록 수정
                     event.eventId(),
                     event.userId(),
                     event.amount(),
                     PointType.CREDIT,
                     event.betId()
             );
-            userKafkaProducer.send(balanceEvent);
+            String payload = objectMapper.writeValueAsString(balanceEvent);
+            OutboxEvent outboxEvent = new OutboxEvent(
+                    UUID.fromString(sagaId),
+                    UUID.fromString(event.eventId()),
+                    event.userId(),
+                    payload
+            );
+            outboxRepository.save(outboxEvent);
+            log.info("[KAKFA-CONUSME] [Betting] Outbox saved - outboxId={}, balanceEventId={}", outboxEvent.getOutboxId(), balanceEvent.eventId());
+            processedBettingEventRepository.save(ProcessedBettingEvent.of(UUID.fromString(event.eventId()), event.userId(), UUID.fromString(event.betId()), event.amount()));
             log.info("[KAFKA-CONSUME] [Betting] Successfully processed eventId={}", event.eventId());
         } catch (BusinessException e) {
             log.error("[KAFKA-CONSUME] [Betting] Business error - eventId={}, errorCode={}", event.eventId(), e.getErrorCode(), e);

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/DltNotificationReceiver.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/DltNotificationReceiver.java
@@ -1,0 +1,64 @@
+package com.oneonone.userservice.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneonone.userservice.infrastructure.kafka.event.BettingEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DltNotificationReceiver {
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    @Value("${slack.web-hook-url}")
+    private String SLACK_WEBHOOK_URL;
+
+    @KafkaListener(
+            topics = "betting-reward.DLT",
+            groupId = "user-service",
+            containerFactory = "dltKafkaListenerContainerFactory"
+    )
+    public void handleDlt(BettingEvent event) {
+        try {
+            log.error("Moved to DLT: {}", event);
+            sendToSlack(event);
+        } catch (Exception e) {
+            log.error("Error processing dlt: {}", e.getMessage());
+        }
+    }
+
+    public void sendToSlack(BettingEvent event) {
+        try {
+            String notification = objectMapper.writeValueAsString(event);
+            String message = String.format("""
+                    !!! DLT Message Detected
+                    Details: ```%s```
+                    """, notification);
+            String payload = objectMapper.writeValueAsString(new SlackPayload(message));
+            restTemplate.postForObject(SLACK_WEBHOOK_URL, payload, String.class);
+            log.info("Processed sending to slack: {}", message);
+        } catch (JsonProcessingException e) {
+            log.error("Error processing JSON: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("Failed to send message: {}", e.getMessage(), e);
+        }
+    }
+
+    private static class SlackPayload {
+        private final String text;
+
+        public SlackPayload(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/event/BettingEvent.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/event/BettingEvent.java
@@ -1,6 +1,7 @@
 package com.oneonone.userservice.infrastructure.kafka.event;
 
 public record BettingEvent(
+        String sagaId,
         String eventId,
         Long userId,
         Long amount,

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/persistence/entity/ProcessedBettingEvent.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/persistence/entity/ProcessedBettingEvent.java
@@ -1,9 +1,6 @@
 package com.oneonone.userservice.infrastructure.persistence.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,14 +15,17 @@ import java.util.UUID;
 public class ProcessedBettingEvent {
 
     @Id
-    @Column
-    private UUID eventId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @Column(nullable = false)
-    private Long userId;
+    private UUID eventId;
 
     @Column(nullable = false, unique = true)
     private UUID betId;
+
+    @Column(nullable = false)
+    private Long userId;
 
     @Column(nullable = false)
     private Long amount;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #68 

## 📝 개요
- DLT에 메시지 수신 시(정상적으로 메시지가 전송되지 않을 때) Slack으로 알림을 전송합니다.
- 현재는 제 개인 슬랙으로 메시지가 전송됩니다.
<img width="537" height="266" alt="스크린샷 2025-12-12 오전 2 08 26" src="https://github.com/user-attachments/assets/85585ddb-1efb-44ca-a093-88428beb33fb" />


## 🔁 변경 사항
- betting -> user 과정에서 sagaId를 도입해 멱등성을 보장하고자 했습니다.
- 기존에는 betting -> user 이벤트 수신 시 바로 포인트 잔액을 업데이트했는데, 이를 outbox 저장 후 poller로 수신하도록 변경했습니다.

## 👀 참고 사항
- .env 파일은 슬랙에 공유드리겠습니다.

## 👀 기타