### PR TITLE
[Feature] Saga ID 분리 로직 적용 및 UserController Balance API 내부/외부 분리

### DIFF
--- a/betting-service/src/main/java/com/oneonone/bettingservice/application/service/BettingService.java
+++ b/betting-service/src/main/java/com/oneonone/bettingservice/application/service/BettingService.java
@@ -139,16 +139,27 @@ public class BettingService {
         // 정산 계산 후 회원 모듈에게 포인트를 수정하도록 요청한다.
         List<BettingEvent> rewards = bets.stream()
                 .filter(Betting::isWin)
-                .map(b -> new BettingEvent(
-                        UUID.randomUUID().toString(),
-                        b.getUserId(),
-                        b.calculateReward(),
-                        b.getId().toString()
-                        )).toList();
+                .map(b -> {
+                    String sagaId = UUID.randomUUID().toString();
+                    String eventId = UUID.randomUUID().toString();
+
+                    log.info("[GAME-RESULT] Creating reward - sagaId={}, betId={}, userId={}, amount={}",
+                            sagaId, b.getId(), b.getUserId(), b.calculateReward());
+
+                    return new BettingEvent(
+                            sagaId,
+                            eventId,
+                            b.getUserId(),
+                            b.calculateReward(),
+                            b.getId().toString()
+                    );
+                })
+                .toList();
 
         // 포인트 서비스 이벤트 발행
         rewards.forEach(event ->
-                kafkaPointReward.send("betting-reward",
+                kafkaPointReward.send(
+                        "betting-reward",
                         event.userId().toString(),  // key: userId
                         event                       // value : Long balance
                 ).whenComplete((result, ex) -> {
@@ -159,5 +170,8 @@ public class BettingService {
                     }
                 })
         );
+
+        log.info("[GAME-RESULT] Game result processed - gameId={}, totalRewards={}",
+                requestDto.gameId(), rewards.size());
     }
 }

--- a/betting-service/src/main/java/com/oneonone/bettingservice/infrastructure/event/BettingEvent.java
+++ b/betting-service/src/main/java/com/oneonone/bettingservice/infrastructure/event/BettingEvent.java
@@ -1,6 +1,7 @@
 package com.oneonone.bettingservice.infrastructure.event;
 
 public record BettingEvent(
+        String sagaId,
         String eventId,
         Long userId,
         Long amount,

--- a/point-service/src/main/java/com/oneonone/pointservice/domain/entity/Point.java
+++ b/point-service/src/main/java/com/oneonone/pointservice/domain/entity/Point.java
@@ -23,11 +23,20 @@ public class Point extends BaseEntity {
     @Column(name="point_id")
     private UUID id;
 
-    @Column(name = "saga_id", nullable = false, updatable = false)
-    private UUID sagaId;    // Saga 전체 흐름 추적
+    /**
+     * Saga 전체 흐름 추적
+     * - 일반 거래: null
+     * - Saga 거래: Saga 식별자
+     */
+    @Column(name = "saga_id")
+    private UUID sagaId;
 
-    @Column(name = "event_id", nullable = false, updatable = false, unique = true)
-    private UUID eventId;   // 개별 메시지 멱등성
+    /**
+     * 개별 이벤트 멱등성 보장
+     * - Saga 거래: 이벤트 식별자 (중복 처리 방지)
+     */
+    @Column(name = "event_id", unique = true)
+    private UUID eventId;
 
     @Enumerated(EnumType.STRING)
     @Column(name="point_type", nullable=false)
@@ -43,11 +52,16 @@ public class Point extends BaseEntity {
     @Column(name="description")
     private String description;
 
+    @Column(name = "bet_id")
     private String betId;
 
     @Column(name="user_id", nullable=false)
     private Long userId;
 
+    /**
+     * 보상 완료 시각
+     * - status가 COMPENSATED일 때만 값 존재
+     */
     @Column(name="compensated_at")
     private LocalDateTime compensatedAt;
 

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BalanceCompensationConsumer.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BalanceCompensationConsumer.java
@@ -84,8 +84,8 @@ public class BalanceCompensationConsumer {
             // 비즈니스 로직 실패 시 실패 신호 전송
             if (event != null) {
                 try {
-                    com.oneonone.userservice.domain.entity.CompensationEvent compensationRecord =
-                            com.oneonone.userservice.domain.entity.CompensationEvent.failure(
+                    CompensationEvent compensationRecord =
+                            CompensationEvent.failure(
                                     UUID.fromString(event.eventId()),
                                     event.userId(),
                                     event.amount(),

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BettingConsumer.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/consumer/BettingConsumer.java
@@ -35,6 +35,9 @@ public class BettingConsumer {
     )
     @Transactional
     public void consume(BettingEvent event) {
+        // Betting Service에서 생성한 sagaId
+        String sagaId = event.sagaId();
+
         log.info("[KAFKA-CONSUME] [Betting] Received eventId={}, userId={}: ", event.eventId(), event.userId());
         if (processedBettingEventRepository.existsByBetId(UUID.fromString(event.betId()))) {
             log.warn("[KAFKA-CONSUME] [Betting] Already processed eventId={}", event.eventId());
@@ -48,7 +51,7 @@ public class BettingConsumer {
             user.updateBalance(event.amount(), PointType.CREDIT);
             log.info("[KAFKA-CONSUME] [Betting] PointBalance After Update userId={}, pointBalance={}", user.getUserId(), user.getPointBalance());
             BalanceEvent balanceEvent = new BalanceEvent(
-                    UUID.randomUUID().toString(),
+                    event.sagaId(), // Betting Service에서 생성한 sagaId
                     event.eventId(),
                     event.userId(),
                     event.amount(),

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/event/BettingEvent.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/kafka/event/BettingEvent.java
@@ -1,6 +1,7 @@
 package com.oneonone.userservice.infrastructure.kafka.event;
 
 public record BettingEvent(
+        String sagaId,
         String eventId,
         Long userId,
         Long amount,

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Slf4j
 @Tag(
         name = "User API",
         description = "회원가입 및 로그인을 비롯한 사용자를 담당하는 API"
@@ -201,10 +203,9 @@ public class UserController {
     }
 
     @Operation(
-            summary = "사용자 포인트 잔액 조회 - 서비스 간 통신용",
+            summary = "사용자 포인트 잔액 조회 - 관리자용",
             description = "관리자가 특정 사용자의 포인트 잔액을 조회합니다."
     )
-    // TODO: 통신용은 Internal로 분리하면 좋을 듯
     @PreAuthorize("hasRole('MASTER')")
     @GetMapping("/{userId}/balance")
     public ResponseEntity<ApiResponse<BalanceResponse>> getBalance(
@@ -215,8 +216,15 @@ public class UserController {
     }
 
     @Operation(
-            summary = "사용자 포인트 잔액 수정 - 서비스 간 통신용",
-            description = "관리자가 특정 사용자의 포인트를 증가/감소시킵니다."
+            summary = "사용자 포인트 잔액 수정 - 관리자 전용",
+            description = """
+                    관리자가 사용자의 포인트를 직접 증가/감소시킵니다.
+                    - 수동 보상 지급
+                    - 패널티 차감
+                    - 데이터 정정
+                    
+                    서비스 간 통신(Betting Service)은 /api/v1/internal/users/{userId}/balance 사용
+                    """
     )
     @PreAuthorize("hasRole('MASTER')")
     @PatchMapping("/{userId}/balance")
@@ -225,13 +233,23 @@ public class UserController {
             @PathVariable Long userId,
             @Parameter(description = "포인트 증감량(증가: 양수, 감소: 음수)", required = true)
             @RequestBody UpdateBalanceRequest request) {
+
+        if (request.sagaId() != null) {
+            throw new IllegalArgumentException("Admin API는 sagaId를 보내면 안 됩니다");
+        }
+
+        // 새로운 Saga 시작
         UUID sagaId = UUID.randomUUID();
+        log.info("[ADMIN-API] Balance adjustment - sagaId={}, userId={}, amount={}",
+                sagaId, userId, request.amount());
+
         UpdateBalanceCommand command = new UpdateBalanceCommand(
-                sagaId, // TODO: sagaId는 호출하는 쪽 (Betting Service)가 관리하도록 수정
+                sagaId,
                 request.amount(),
                 request.type(),
                 UUID.randomUUID(),
-                request.betId());
+                null
+        );
         BalanceResponse response = userService.updateBalance(userId, command);
         return ResponseEntity.ok(ApiResponse.success(response, "사용자 포인트 밸런스 수정 성공"));
     }

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateBalanceRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/UpdateBalanceRequest.java
@@ -12,7 +12,6 @@ public record UpdateBalanceRequest(
         @NotNull(message = "타입은 필수입니다")
         PointType type,  // "DEBIT" or "CREDIT"
 
-        @NotNull(message = "Saga ID는 필수입니다")
         UUID sagaId,
 
         // betId는 선택적 (베팅 관련 작업에만 필요)

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/internal/InternalUserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/internal/InternalUserController.java
@@ -1,0 +1,86 @@
+package com.oneonone.userservice.presentation.internal;
+
+import com.oneonone.common.response.ApiResponse;
+import com.oneonone.userservice.application.command.UpdateBalanceCommand;
+import com.oneonone.userservice.application.service.UserService;
+import com.oneonone.userservice.presentation.dto.request.UpdateBalanceRequest;
+import com.oneonone.userservice.presentation.dto.response.BalanceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(
+        name = "Internal API - User",
+        description = "마이크로서비스 간 통신 전용 API (외부 노출 금지)"
+)
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/internal/users")
+public class InternalUserController {
+
+    private final UserService userService;
+
+    @Operation(
+            summary = "포인트 잔액 수정 - 서비스 간 통신 전용",
+            description = """
+            Betting Service 등 다른 마이크로서비스가 사용자의 포인트를 수정합니다.
+            - sagaId는 호출하는 서비스(Betting Service)에서 생성하여 전달
+            - 내부 네트워크에서만 접근 가능
+            - Service-to-Service 인증 필요
+            """
+    )
+    @PatchMapping("/{userId}/balance")
+    public ResponseEntity<ApiResponse<BalanceResponse>> updateBalance(
+            @Parameter(description = "포인트 잔액을 수정할 사용자 ID", required = true)
+            @PathVariable Long userId,
+            @Parameter(description = "포인트 증감량(증가: 양수, 감소: 음수)", required = true)
+            @Valid @RequestBody UpdateBalanceRequest request) {
+
+        log.info("[INTERNAL-API] Balance update request - sagaId={}, userId={}, amount={}, type={}",
+                request.sagaId(), userId, request.amount(), request.type());
+
+        // Saga ID 검증
+        if (request.sagaId() == null) {
+            log.error("[INTERNAL-API] sagaId is required for internal API calls");
+            throw new IllegalArgumentException("sagaId는 필수입니다 (호출하는 서비스에서 생성 필요)");
+        }
+
+        UpdateBalanceCommand command = new UpdateBalanceCommand(
+                request.sagaId(),        // TODO: sagaId는 호출하는 쪽 (Betting Service)가 관리하도록 수정
+                request.amount(),
+                request.type(),
+                UUID.randomUUID(),       // eventId는 여기서 생성
+                request.betId()
+        );
+
+        BalanceResponse response = userService.updateBalance(userId, command);
+
+        log.info("[INTERNAL-API] Balance updated - sagaId={}, userId={}, newBalance={}",
+                request.sagaId(), userId, response.pointBalance());
+
+        return ResponseEntity.ok(ApiResponse.success(response, "포인트 수정 완료"));
+    }
+
+    @Operation(
+            summary = "포인트 잔액 조회 - 서비스 간 통신 전용",
+            description = "다른 마이크로서비스가 사용자의 포인트 잔액을 조회합니다."
+    )
+    @GetMapping("/{userId}/balance")
+    public ResponseEntity<ApiResponse<BalanceResponse>> getBalance(
+            @Parameter(description = "사용자 ID", required = true)
+            @PathVariable Long userId) {
+
+        log.info("[INTERNAL-API] Balance query - userId={}", userId);
+
+        BalanceResponse response = userService.getPoint(userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "포인트 잔액 조회 완료"));
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #67 

## 📝 개요
- 일반 입출금 요청과 Betting 이벤트의 Saga 흐름을 분리하여 정확한 출처에서 Saga ID가 생성되도록 개선하였음.
- Balance 수정 API를 외부(Admin/Client)용과 내부 마이크로서비스 호출용으로 분리하여 책임 분명화 및 보안 강화.

## 🔁 변경 사항
- 일반 입출금 시 user-service에서 sagaId를 생성하도록 수정
- Betting 서비스에서는 sagaId를 직접 생성해 이벤트로 전달하도록 구조 변경

- UserController balance 관련 API를
외부용: /api/v1/users/{userId}/balance
내부용: /internal/v1/users/{userId}/balance
로 분리

 - 내부 API는 인증/인가 체크 없이 내부 통신 전용으로 설정
- 기존 로직에서 saga 생성 위치 및 Controller 책임을 리팩터링
- 관련 DTO/Command 구조 일부 정리

## 👀 참고 사항
- API는 Gateway에서 접근 차단 또는 내부 토큰 기반으로 호출 예정


## 👀 기타
- Betting 서비스 쪽 Saga ID 생성 방식 적용 후 통합 테스트 필요
- 향후 Deposit/Withdraw 흐름에도 동일 구조 적용 예정
- Swagger 문서도 외부용 API만 노출되도록 조정해야 함