### PR TITLE
[Feat] 회원가입 시 이메일 인증

### DIFF
--- a/api-gateway/src/main/java/com/oneonone/apigateway/filter/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/oneonone/apigateway/filter/AuthenticationFilter.java
@@ -91,7 +91,8 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
                 || path.startsWith("/webjars")
                 || path.startsWith("/actuator")
                 || path.startsWith("/api/v1/users/signup")
-                || path.startsWith("/api/v1/users/login");
+                || path.startsWith("/api/v1/users/login")
+                || path.startsWith("/api/v1/users/email/");
     }
 
     private Mono<Void> onError(ServerWebExchange exchange, String message, HttpStatus status) {

--- a/config-server/src/main/resources/config-repo/user-service.yml
+++ b/config-server/src/main/resources/config-repo/user-service.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: user-service
   datasource:
-    #url: jdbc:postgresql://localhost:5432/oneonone?currentSchema=users(dev)
+#    url: jdbc:postgresql://localhost:5432/oneonone
     url: jdbc:postgresql://postgres:5432/oneonone
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
@@ -22,6 +22,7 @@ spring:
 
   kafka:
     bootstrap-servers: kafka:29092
+#    bootstrap-servers: localhost:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
@@ -55,9 +56,19 @@ spring:
 
   data:
     redis:
+#      host: localhost
       host: redis      # docker-compose 서비스 이름
       port: 6379
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+    verification: 300
 
   cloud:
     service-bindings:
@@ -71,5 +82,3 @@ management:
     web:
       exposure:
         include: refresh
-
-

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/oneonone/userservice/UserServiceApplication.java
@@ -28,5 +28,4 @@ public class UserServiceApplication {
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
-
 }

--- a/user-service/src/main/java/com/oneonone/userservice/application/command/EmailCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/EmailCommand.java
@@ -1,0 +1,6 @@
+package com.oneonone.userservice.application.command;
+
+public record EmailCommand(
+        String email
+) {
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/command/EmailVerifyCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/EmailVerifyCommand.java
@@ -1,0 +1,6 @@
+package com.oneonone.userservice.application.command;
+
+public record EmailVerifyCommand(
+        String email,
+        String code
+) {}

--- a/user-service/src/main/java/com/oneonone/userservice/application/command/SignupCommand.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/command/SignupCommand.java
@@ -5,6 +5,7 @@ import com.oneonone.common.enums.UserRole;
 public record SignupCommand(
         String username,
         String password,
+        String email,
         String nickname,
         String slackId,
         UserRole role

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/EmailService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/EmailService.java
@@ -1,0 +1,29 @@
+package com.oneonone.userservice.application.service;
+
+import com.oneonone.common.exception.BusinessException;
+import com.oneonone.userservice.exception.UserErrorCode;
+import com.oneonone.userservice.infrastructure.mail.MailService;
+import com.oneonone.userservice.infrastructure.mail.RedisService;
+import com.oneonone.userservice.presentation.dto.response.EmailVerifyResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final MailService mailService;
+    private final RedisService redisService;
+
+    public void sendCode(String email) {
+        String code = mailService.generateCode();
+        mailService.send(email, code);
+        redisService.setCode(email, code);
+    }
+
+    public EmailVerifyResponse verifyCode(String email, String code) {
+        String saved = redisService.getCode(email);
+        if (!saved.equals(code)) throw new BusinessException(UserErrorCode.INVALID_EMAIL_VERIFICATION_CODE);
+        return EmailVerifyResponse.from(code);
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -3,10 +3,7 @@ package com.oneonone.userservice.application.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneonone.common.exception.BusinessException;
-import com.oneonone.userservice.application.command.SignupCommand;
-import com.oneonone.userservice.application.command.UpdateBalanceCommand;
-import com.oneonone.userservice.application.command.UpdateMasterCommand;
-import com.oneonone.userservice.application.command.UpdateUserCommand;
+import com.oneonone.userservice.application.command.*;
 import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.application.event.BalanceEventPayload;
 import com.oneonone.userservice.domain.entity.OutboxEvent;
@@ -46,6 +43,7 @@ public class UserService {
         User user = User.create(
                 command.username(),
                 encodedPassword,
+                command.email(),
                 command.nickname(),
                 command.slackId(),
                 command.role()

--- a/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/entity/User.java
@@ -28,6 +28,9 @@ public class User extends BaseEntity {
     private String password;
 
     @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
     private String nickname;
 
     @Column(nullable = false)
@@ -46,12 +49,14 @@ public class User extends BaseEntity {
 
     public static User create(String username,
                               String encodedPassword,
+                              String email,
                               String nickname,
                               String slackId,
                               UserRole role) {
         return User.builder()
                 .username(username)
                 .password(encodedPassword)
+                .email(email)
                 .nickname(nickname)
                 .status(UserStatus.ACTIVE)
                 .role(role == null ? UserRole.USER : role)

--- a/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/oneonone/userservice/exception/UserErrorCode.java
@@ -17,8 +17,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_POINT(HttpStatus.BAD_REQUEST, "U006", "포인트는 음수가 될 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "U007", "유효하지 않은 토큰입니다."),
     INVALID_POINT_TYPE(HttpStatus.BAD_REQUEST, "U008", "포인트 타입은 DEBIT 또는 CREDIT이어야 합니다."),
-    OUTBOX_PAYLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "U009", "Outbox payload 생성에 실패했습니다.")
-    ;
+    OUTBOX_PAYLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "U009", "Outbox payload 생성에 실패했습니다."),
+    INVALID_EMAIL_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "U010", "유효하지 않은 인증 코드입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/mail/MailService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/mail/MailService.java
@@ -1,0 +1,53 @@
+package com.oneonone.userservice.infrastructure.mail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final MailProperties mailProperties;
+
+    public MailService(JavaMailSender javaMailSender, MailProperties mailProperties) {
+        this.javaMailSender = javaMailSender;
+        this.mailProperties = mailProperties;
+    }
+
+    private static final String EMAIL_TITLE = "회원 가입을 위한 인증 이메일";
+    private static final String EMAIL_CONTENT = "아래의 인증 번호를 입력하여 회원 가입을 완료해주세요." +
+            "<br><br>" +
+            "인증번호: %s" +
+            "<br><br>인증 번호의 유효 시간은 5분입니다.";
+
+    public void send(String email, String code) {
+        String content = String.format(EMAIL_CONTENT, code);
+        mailSend(mailProperties.getUsername(), email, EMAIL_TITLE, content);
+    }
+
+    public String generateCode() {
+        return String.format("%06d", new Random().nextInt(1000000));
+    }
+
+    public void mailSend(String setFrom, String toMail, String title, String content) {
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(setFrom);
+            helper.setTo(toMail);
+            helper.setSubject(title);
+            helper.setText(content, true);
+            javaMailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("Email send failed", e);
+        }
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/mail/RedisService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/mail/RedisService.java
@@ -1,0 +1,25 @@
+package com.oneonone.userservice.infrastructure.mail;
+
+import com.oneonone.common.exception.BusinessException;
+import com.oneonone.userservice.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setCode(String email, String code) {
+        redisTemplate.opsForValue().set(email, code, 300, TimeUnit.SECONDS);
+    }
+
+    public String getCode(String email) {
+        String code = redisTemplate.opsForValue().get(email);
+        if (code == null) throw new BusinessException(UserErrorCode.INVALID_EMAIL_VERIFICATION_CODE);
+        return code;
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/security/UserSecurityConfig.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/security/UserSecurityConfig.java
@@ -29,6 +29,7 @@ public class UserSecurityConfig implements SecurityConfigurer {
                                 "/api/v1/users/signup",
                                 "/api/v1/users/login",
                                 "/api/v1/users/reissue",
+                                "/api/v1/users/email/**",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/v3/api-docs",

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/UserController.java
@@ -3,6 +3,7 @@ package com.oneonone.userservice.presentation;
 import com.oneonone.common.response.ApiResponse;
 import com.oneonone.userservice.application.command.*;
 import com.oneonone.userservice.application.service.AuthService;
+import com.oneonone.userservice.application.service.EmailService;
 import com.oneonone.userservice.application.service.UserService;
 import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.presentation.dto.request.*;
@@ -36,6 +37,7 @@ public class UserController {
 
     private final UserService userService;
     private final AuthService authService;
+    private final EmailService emailService;
 
     @Operation(
             summary = "회원가입",
@@ -48,6 +50,7 @@ public class UserController {
         SignupCommand command = new SignupCommand(
                 request.username(),
                 request.password(),
+                request.email(),
                 request.nickname(),
                 request.slackId(),
                 request.role()
@@ -55,6 +58,30 @@ public class UserController {
         User user = userService.signUp(command);
         SignupResponse response = SignupResponse.from(user);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "회원가입 완료"));
+    }
+
+    @Operation(
+            summary = "이메일 전송",
+            description = "입력한 이메일로 인증번호를 발송합니다."
+    )
+    @PostMapping("/email/send")
+    public ResponseEntity<ApiResponse<Void>> sendEmail(
+            @Valid @RequestBody EmailRequest request) {
+        EmailCommand command = new EmailCommand(request.email());
+        emailService.sendCode(command.email());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(
+            summary = "인증코드 검증",
+            description = "Redis에 저장되어 있는 인증코드와 입력한 인증코드가 일치하는지 확인합니다."
+    )
+    @GetMapping("/email/verify")
+    public ResponseEntity<ApiResponse<EmailVerifyResponse>> verifyEmail(
+            @Valid EmailVerifyRequest request) {
+        EmailVerifyCommand command = new EmailVerifyCommand(request.email(), request.code());
+        EmailVerifyResponse response = emailService.verifyCode(command.email(), command.code());
+        return ResponseEntity.ok(ApiResponse.success(response, "이메일 인증 성공"));
     }
 
     @Operation(

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/EmailRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/EmailRequest.java
@@ -1,0 +1,10 @@
+package com.oneonone.userservice.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailRequest(
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email
+) {}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/EmailVerifyRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/EmailVerifyRequest.java
@@ -1,0 +1,8 @@
+package com.oneonone.userservice.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerifyRequest(
+        @NotBlank String email,
+        @NotBlank String code
+) {}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/SignupRequest.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/request/SignupRequest.java
@@ -1,6 +1,7 @@
 package com.oneonone.userservice.presentation.dto.request;
 
 import com.oneonone.common.enums.UserRole;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -11,6 +12,9 @@ public record SignupRequest(
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,15}$",
                 message = "비밀번호는 영문 대소문자와 숫자, 특수문자를 포함한 8~15자로 구성되어야 합니다.")
         String password,
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email,
         @NotBlank(message = "닉네임은 필수입니다.")
         String nickname,
         @NotBlank(message = "슬랙 ID는 필수입니다.")

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/EmailVerifyResponse.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/EmailVerifyResponse.java
@@ -1,0 +1,9 @@
+package com.oneonone.userservice.presentation.dto.response;
+
+public record EmailVerifyResponse(
+        String code
+) {
+    public static EmailVerifyResponse from(String code) {
+        return new EmailVerifyResponse(code);
+    }
+}

--- a/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/SignupResponse.java
+++ b/user-service/src/main/java/com/oneonone/userservice/presentation/dto/response/SignupResponse.java
@@ -5,6 +5,7 @@ import com.oneonone.userservice.domain.entity.User;
 import com.oneonone.userservice.domain.enums.UserStatus;
 public record SignupResponse(
         String username,
+        String email,
         String nickname,
         UserRole role,
         UserStatus status,
@@ -13,6 +14,7 @@ public record SignupResponse(
     public static SignupResponse from(User user) {
         return new SignupResponse(
                 user.getUsername(),
+                user.getEmail(),
                 user.getNickname(),
                 user.getRole(),
                 user.getStatus(),


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #75 

## 📝 개요
- 회원가입을 진행하기 전 진행될 이메일 인증 기능을 구현했습니다.
- 이메일 발송과 함께 Redis에 {이메일:인증 번호} 형태로 저장되며, Redis에 저장된 값과 사용자가 입력한 인증 번호 값을 비교합니다.

**⬇️ 과정**
- 이메일 형식에 맞게 요청하면 이메일이 발송됩니다.
<img width="405" height="190" alt="스크린샷 2025-12-12 오후 11 48 59" src="https://github.com/user-attachments/assets/ce74c8e9-d6bd-4314-97e9-c05bd15b277f" />

- 인증 번호와 동일한 숫자 입력 시 인증 / 다른 숫자 입력 시 인증 불가
<img width="489" height="192" alt="스크린샷 2025-12-12 오후 6 23 41" src="https://github.com/user-attachments/assets/2f70e74e-139e-4f4b-ab0b-5dab42db4f3c" />
<img width="516" height="287" alt="스크린샷 2025-12-12 오후 6 23 50" src="https://github.com/user-attachments/assets/92ab4272-3138-40a6-b866-0d3cdacbb9f0" />

- 5분이 지나면 인증 번호를 사용할 수 없습니다.
<img width="556" height="267" alt="스크린샷 2025-12-12 오후 6 29 06" src="https://github.com/user-attachments/assets/679afb40-ecd7-4753-82f5-0a98a26c2915" />

## 🔁 변경 사항
- 변경 사항을 작성해주세요.

## 👀 참고 사항
- .env 파일 내용은 슬랙으로 전달드리겠습니다.
- 추가 구현 고려 사항: 이메일 인증 횟수 제한

## 👀 기타