### PR TITLE
[Feature] 포인트 수정 로직에 비관적 락(Pessimistic Lock) 적용

### DIFF
--- a/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/oneonone/userservice/application/service/UserService.java
@@ -141,13 +141,21 @@ public class UserService {
             return new BalanceResponse(userId, user.getPointBalance());
         }
 
-        User user = findUserById(userId);
+        // 성능 개선을 위해 락 없이 먼저 구현, 나중에 낙관적/비관적 락 구현
+//        User user = findUserById(userId);
+
+        // 비관적 락으로 사용자 조회
+        // 포인트 차감은 동시성 충돌 가능성이 높아
+        // PESSIMISTIC_WRITE 락을 사용하여
+        // 동일 사용자에 대한 Balance 업데이트를 직렬화함
+        User user = userRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         // Balance 업데이트
-        // 성능 개선을 위해 락 없이 먼저 구현, 나중에 낙관적/비관적 락 구현
-        // User 조회 및 Balance 업데이트
         user.updateBalance(command.amount(), command.type());
-        log.info("업데이트 완료");
+        log.info("[BALANCE-UPDATE] Balance updated. userId={}, balance={}",
+                userId, user.getPointBalance());
+
         // Outbox payload 생성
         BalanceEventPayload event = new BalanceEventPayload(
                 command.sagaId().toString(),

--- a/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/domain/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository {
     boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 
     Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Optional<User> findByUserIdForUpdate(Long userId);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/JpaUserRepository.java
@@ -2,9 +2,13 @@ package com.oneonone.userservice.infrastructure.repository;
 
 import com.oneonone.userservice.application.dto.UserInfo;
 import com.oneonone.userservice.domain.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -18,4 +22,9 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
     boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 
     Optional<User> findByUsernameAndDeletedAtIsNull(String username);
+
+    // 비관적 락 구현
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.userId = :userId and u.deletedAt is null")
+    Optional<User> findByUserIdForUpdate(@Param("userId") Long userId);
 }

--- a/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/oneonone/userservice/infrastructure/repository/UserRepositoryImpl.java
@@ -45,4 +45,9 @@ public class UserRepositoryImpl implements UserRepository {
     public Page<UserInfo> findAllByDeletedAtIsNull(Pageable pageable) {
         return jpaUserRepository.findAllByDeletedAtIsNull(pageable);
     }
+
+    @Override
+    public Optional<User> findByUserIdForUpdate(Long userId) {
+        return jpaUserRepository.findByUserIdForUpdate(userId);
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #82

## 📝 개요
- 포인트 차감/증가 API에 비관적 락(PESSIMISTIC_WRITE)을 적용하여 동시 요청 환경에서도 포인트 잔액의 정합성을 보장합니다.
- 성능 테스트 결과를 기반으로 낙관적 락 및 분산 락 대신 비관적 락을 최종 동시성 제어 전략으로 선택했습니다.

## 🔁 변경 사항
- 포인트 수정 API(updateBalance)에서 사용자 조회 시 비관적 락 적용
- 동일 사용자에 대한 포인트 업데이트를 트랜잭션 내에서 직렬화
- 기존 멱등성 처리(eventId) 및 Outbox 패턴 로직은 유지
- 조회 전용 API에는 락 미적용

## 👀 참고 사항
- 포인트 수정은 쓰기 충돌 가능성이 높은 핵심 도메인 로직으로 안정성을 최우선으로 고려했습니다.
- 낙관적 락 대비 재시도 비용이 없으며, 성능 테스트 결과 실패율 0%를 확인했습니다.

## 👀 기타